### PR TITLE
Fixed "check_if_type_in_tree". Added new member functions to API 

### DIFF
--- a/src/cjparse.cpp
+++ b/src/cjparse.cpp
@@ -8,8 +8,73 @@ cjparse::cjparse (std::stringstream &fake_str)
     // to be determied
 }
 
+cjparse::json_value
+cjparse::return_the_value (std::string &name_to_return_value)
+{
+    json_value value;
+    std::optional<json_value> when_valid_return
+        = return_the_value_internal (name_to_return_value);
+    if (when_valid_return.has_value ())
+        return when_valid_return;
+    else
+        return value;
+}
+
+cjparse::json_value
+cjparse::return_the_value_in_tree (std::string &name_to_return_value)
+{
+    json_value value;
+    std::optional<json_value> when_valid_return
+        = return_the_value_in_tree_internal (name_to_return_value);
+    if (when_valid_return.has_value ())
+        return when_valid_return;
+    else
+        return value;
+}
+
+template <class T>
+bool
+cjparse::check_if_type (std::string &name_to_check_if_type)
+{
+    bool bool_to_return;
+    std::optional<bool> when_valid_return
+        = check_if_type_internal<T> (name_to_check_if_type);
+    if (when_valid_return.has_value ())
+        return when_valid_return.value ();
+    else
+        return false;
+}
+
+template <class T>
+bool
+cjparse::check_if_type_in_tree (std::string &name_to_check_if_type)
+{
+    bool bool_to_return;
+    std::optional<bool> when_valid_return
+        = check_if_type_in_tree_internal<T> (name_to_check_if_type);
+    if (when_valid_return.has_value ())
+        return when_valid_return.value ();
+    else
+        return false;
+}
+
+template <class T>
+bool
+cjparse::check_if_type_inside_object (std::string &name_of_object_container,
+                                      std::string &name_to_check_if_type)
+{
+    bool bool_to_return;
+    std::optional<bool> when_valid_return
+        = check_if_type_inside_object_internal<T> (name_of_object_container,
+                                                   name_to_check_if_type);
+    if (when_valid_return.has_value ())
+        return when_valid_return.value ();
+    else
+        return false;
+}
+
 std::optional<cjparse::json_value>
-cjparse::return_the_value (std::string &name)
+cjparse::return_the_value_internal (std::string &name)
 {
     if (!std::holds_alternative<json_object> (JSON.value))
         {
@@ -81,7 +146,7 @@ cjparse::return_the_value_in_tree_helper (
 }
 
 std::optional<cjparse::json_value>
-cjparse::return_the_value_in_tree (std::string &name_to_return_value)
+cjparse::return_the_value_in_tree_internal (std::string &name_to_return_value)
 {
     std::optional<json_value> value_to_return;
 
@@ -97,7 +162,7 @@ cjparse::return_the_value_in_tree (std::string &name_to_return_value)
 
 template <class T>
 std::optional<bool>
-cjparse::check_if_type (std::string &name)
+cjparse::check_if_type_internal (std::string &name)
 {
     // JSON not an object so no key value pairs
     if (!std::holds_alternative<json_object> (JSON.value))
@@ -126,7 +191,6 @@ void
 cjparse::check_if_type_in_tree_helper (std::optional<bool> &bool_to_alter,
                                        std::string &name, json_value &value_in)
 {
-    std::cout << "We are here..." << '\n';
     if (std::holds_alternative<json_object> (value_in))
         {
             auto &json_obj = std::get<json_object> (value_in);
@@ -176,7 +240,7 @@ cjparse::check_if_type_in_tree_helper (std::optional<bool> &bool_to_alter,
 
 template <class T>
 std::optional<bool>
-cjparse::check_if_type_in_tree (std::string &name)
+cjparse::check_if_type_in_tree_internal (std::string &name)
 {
     std::optional<bool> bool_to_return;
 
@@ -191,19 +255,25 @@ cjparse::check_if_type_in_tree (std::string &name)
 
 template <class T>
 std::optional<bool>
-cjparse::check_if_type_inside_object (std::string &name_of_object_container,
-                                      std::string &name_to_check_if_type)
+cjparse::check_if_type_inside_object_internal (
+    std::string &name_of_object_container, std::string &name_to_check_if_type)
 {
     std::optional<bool> bool_to_return;
+    std::optional<bool> bool_to_find_container;
 
     json_value value;
 
     std::visit ([&value] (auto &value_in) { value = value_in; }, JSON.value);
 
     check_if_type_in_tree_helper<json_object> (
-        bool_to_return, name_of_object_container, value);
+        bool_to_find_container, name_of_object_container, value);
 
-    if (bool_to_return != std::nullopt)
+    if (bool_to_find_container != std::nullopt)
+        {
+            value = return_the_value_in_tree (name_of_object_container);
+            check_if_type_in_tree_helper<T> (bool_to_return,
+                                             name_to_check_if_type, value);
+        }
 
-        return bool_to_return;
+    return bool_to_return;
 }

--- a/src/cjparse.h
+++ b/src/cjparse.h
@@ -62,23 +62,20 @@ class cjparse
     cjparse_json_value JSON;
 
   public:
-    std::optional<json_value>
-    return_the_value (std::string &name_to_return_value);
+    json_value return_the_value (std::string &name_to_return_value);
     /*
      * returns the value of the object with inputted name in
      * the first layer of json
      * returns type "cjparse::json_value"
      * 'std::variant::variant_npos' if obj with name not found
      */
-    std::optional<json_value>
-    return_the_value_in_tree (std::string &name_to_return_value);
+    json_value return_the_value_in_tree (std::string &name_to_return_value);
     /*
      * returns the value of the object with inputted name
      * of type "cjparse::json_value" in the first layer of json
      * returns 'std::variant::variant_npos' if obj with name not found
      */
-    template <class T>
-    std::optional<bool> check_if_type (std::string &name_to_check_if_type);
+    template <class T> bool check_if_type (std::string &name_to_check_if_type);
     /*
      * searches for the value of object with inputted name in the first layer
      * of json tree
@@ -90,8 +87,7 @@ class cjparse
      */
 
     template <class T>
-    std::optional<bool>
-    check_if_type_in_tree (std::string &name_to_check_if_type);
+    bool check_if_type_in_tree (std::string &name_to_check_if_type);
     /*
      * searches for the value of object with inputted name int the FULL json
      * tree returns the value of first obj with name it finds
@@ -104,9 +100,28 @@ class cjparse
      * returns 'std::nullopt' if obj with name not found in the full JSON
      */
     template <class T>
+    bool check_if_type_inside_object (std::string &name_of_object_container,
+                                      std::string &name_to_check_if_type);
+
+  private:
+    std::optional<json_value>
+    return_the_value_internal (std::string &name_to_return_value);
+
+    std::optional<json_value>
+    return_the_value_in_tree_internal (std::string &name_to_return_value);
+
+    template <class T>
     std::optional<bool>
-    check_if_type_inside_object (std::string &name_of_object_container,
-                                 std::string &name_to_check_if_type);
+    check_if_type_internal (std::string &name_to_check_if_type);
+
+    template <class T>
+    std::optional<bool>
+    check_if_type_in_tree_internal (std::string &name_to_check_if_type);
+
+    template <class T>
+    std::optional<bool> check_if_type_inside_object_internal (
+        std::string &name_of_object_container,
+        std::string &name_to_check_if_type);
 
   private:
     void

--- a/src/cjparse.h
+++ b/src/cjparse.h
@@ -62,12 +62,23 @@ class cjparse
     cjparse_json_value JSON;
 
   public:
+    std::optional<json_value>
+    return_the_value (std::string &name_to_return_value);
+    /*
+     * returns the value of the object with inputted name in
+     * the first layer of json
+     * returns type "cjparse::json_value"
+     * 'std::variant::variant_npos' if obj with name not found
+     */
+    std::optional<json_value>
+    return_the_value_in_tree (std::string &name_to_return_value);
     /*
      * returns the value of the object with inputted name
-     * of type "cjparse::json_value"
+     * of type "cjparse::json_value" in the first layer of json
      * returns 'std::variant::variant_npos' if obj with name not found
      */
-    std::optional<json_value> return_the_value (std::string &name);
+    template <class T>
+    std::optional<bool> check_if_type (std::string &name_to_check_if_type);
     /*
      * searches for the value of object with inputted name in the first layer
      * of json tree
@@ -77,10 +88,13 @@ class cjparse
      * what the function name describes (obj, array, number, etc)
      * 'std::nullopt' if obj with name "name" was not found
      */
-    template <class T> std::optional<bool> check_if_type (std::string &name);
+
+    template <class T>
+    std::optional<bool>
+    check_if_type_in_tree (std::string &name_to_check_if_type);
     /*
      * searches for the value of object with inputted name int the FULL json
-     * tree
+     * tree returns the value of first obj with name it finds
      * returns true if it obj with name "name" exists and obj with name
      * "name" has value of what the function name describes (obj, array,
      * number, etc)
@@ -89,11 +103,15 @@ class cjparse
      * number, etc)
      * returns 'std::nullopt' if obj with name not found in the full JSON
      */
-
     template <class T>
-    std::optional<bool> check_if_type_in_tree (std::string &name);
+    std::optional<bool>
+    check_if_type_inside_object (std::string &name_of_object_container,
+                                 std::string &name_to_check_if_type);
 
   private:
+    void
+    return_the_value_in_tree_helper (std::optional<json_value> &value_to_alter,
+                                     std::string &name, json_value &value);
     template <class T>
     void check_if_type_in_tree_helper (std::optional<bool> &bool_to_alter,
                                        std::string &name, json_value &value);

--- a/src/cjparse_json_generate.cpp
+++ b/src/cjparse_json_generate.cpp
@@ -7,6 +7,14 @@ cjparse_json_generator::cjparse_json_generator (
     print_json_from_memory (JSON);
 }
 
+cjparse_json_generator::cjparse_json_generator (cjparse::json_value &JSON,
+                                                bool generate_pretty_json)
+{
+    pretty = generate_pretty_json;
+    cjparse::cjparse_json_value new_value (JSON);
+    print_json_from_memory (new_value);
+}
+
 void
 cjparse_json_generator::print_json_from_memory (
     cjparse::cjparse_json_value &JSON)

--- a/src/cjparse_json_generate.h
+++ b/src/cjparse_json_generate.h
@@ -9,6 +9,8 @@ class cjparse_json_generator
   public:
     cjparse_json_generator (cjparse::cjparse_json_value &JSON,
                             bool generate_pretty_json);
+    cjparse_json_generator (cjparse::json_value &JSON,
+                            bool generate_pretty_json);
 
   public:
     void print_json_from_memory (cjparse::cjparse_json_value &JSON);

--- a/src/main_cjparse.cpp
+++ b/src/main_cjparse.cpp
@@ -92,10 +92,10 @@ main ()
         {
             if (shouldnt_be_null == true)
                 std::cout << "object named: " << obj_name
-                          << "  has value type object" << '\n';
+                          << "  has value type T (tempate)" << '\n';
             else
                 std::cout << "object named: " << obj_name
-                          << " has value type NOT object" << '\n';
+                          << " has value type NOT T (template)" << '\n';
         }
     else
         {

--- a/src/main_cjparse.cpp
+++ b/src/main_cjparse.cpp
@@ -15,17 +15,17 @@ std::string json_2 = R"({
             "Animated" : false,
             "IDs": [116, 943, 234, 38793]
           },
-        "Image": {
-            "Width":  800,
-            "Height": 600,
-            "Title":  "View from 15th Floor",
+        "Image2": {
+            "Width":  200,
+            "Height": 900,
+            "Title":  "View from 10th Floor",
             "Thumbnail": {
-                "Url":    "http://www.example.com/image/481989943",
-                "Height": 125,
-                "Width":  100
+                "Url":    "http://www.example.com/image/92837592",
+                "Height": 260,
+                "Width": 1000 
             },
-            "Animated" : false,
-            "IDs": [116, 943, 234, 38793]
+            "Animated" : true,
+            "IDs": [899, 831, 254, 648953]
           }
       })";
 
@@ -59,7 +59,7 @@ main ()
 {
     // Create the parser with the given JSON string (assuming cjparse class has
     // a constructor that takes a string)
-    cjparse parser (json_1);
+    cjparse parser (json_2);
 
     // Print the JSON structure
     std::cout << "Parsed JSON: \n";
@@ -67,7 +67,15 @@ main ()
         = cjparse_json_generator (parser.JSON, true);
     std::cout << JSON_gen.JSON_string << "\n";
 
-    std::string obj_name = "Image";
+    // testing return_value
+    std::string obj_name = "Image2";
+    cjparse::json_value value_of_obj_name = parser.return_the_value (obj_name);
+    JSON_gen = cjparse_json_generator (value_of_obj_name, true);
+    std::cout << "here it comes return the value : " << '\n'
+              << JSON_gen.JSON_string << '\n';
+
+    // testing check_if_type
+    obj_name = "Image";
     std::optional<bool> will_be_null
         = parser.check_if_type<cjparse::json_object> (
             obj_name); // will return nullopt
@@ -85,6 +93,8 @@ main ()
             std::cout << "object named: " << obj_name << " was not found "
                       << '\n';
         }
+
+    // testing check_if_type_in_tree
     obj_name = "City";
     std::optional<bool> shouldnt_be_null
         = parser.check_if_type_in_tree<cjparse::json_string> (obj_name);
@@ -102,5 +112,6 @@ main ()
             std::cout << "object named: " << obj_name
                       << " was not found in the tree" << '\n';
         }
+
     return 0;
 };


### PR DESCRIPTION
Fixed "check_if_type_in_tree".  the type comparison with "std::is_same_v" is evaluated at compile time not at runtime so used "std::holds_alternative" to properly compare types.
Added function "return_the_value_in_tree" with its helper function does exactly what the name states, this been returning the value of the object with name "name" 
Also started working on "check_if_type_inside_object" witch should resolve checking types of objects with same names in different containers (kind of an edge case when deeply nested json and objects having name value pairs with values that are objects that have name value pairs witch have same names)