### PR TITLE
API single input overloads are done API is finished (for now)

### DIFF
--- a/src/cjparse.cpp
+++ b/src/cjparse.cpp
@@ -54,6 +54,19 @@ cjparse::return_json_container ()
 }
 
 cjparse::json_value
+cjparse::return_the_value (std::string object_name)
+{
+    bool return_empty
+        = false; // just exists to reuse internal function no other purpose
+    json_value full_json, value_to_return;
+    std::visit ([&full_json] (auto value) { full_json = value; }, JSON.value);
+
+    return_the_value_internal (object_name, full_json, value_to_return,
+                               return_empty);
+    return value_to_return;
+}
+
+cjparse::json_value
 cjparse::return_the_value (std::vector<std::string> object_name_vector_in)
 {
     bool return_empty = false;
@@ -112,6 +125,22 @@ cjparse::return_the_value_internal (std::string object_name,
         }
 
     value_to_return = temp_value;
+}
+
+template <class T>
+bool
+cjparse::check_if_type (std::string object_name)
+{
+    bool bool_to_return = false; // here so we can reuse internal method
+    json_value full_json;
+    std::visit ([&full_json] (auto value) { full_json = value; }, JSON.value);
+
+    json_value temp_value = full_json;
+
+    check_if_type_internal<T> (object_name, temp_value, temp_value,
+                               bool_to_return);
+
+    return bool_to_return;
 }
 
 template <class T>

--- a/src/cjparse.h
+++ b/src/cjparse.h
@@ -70,8 +70,12 @@ class cjparse
 
     template <typename json_type> json_type return_json_container ();
 
+    json_value return_the_value (std::string object_name);
+
     json_value
     return_the_value (std::vector<std::string> object_name_vector_in);
+
+    template <class T> bool check_if_type (std::string object_name);
 
     template <class T>
     bool check_if_type (std::vector<std::string> object_name_vector_in);

--- a/src/main_cjparse.cpp
+++ b/src/main_cjparse.cpp
@@ -67,8 +67,15 @@ main ()
         = cjparse_json_generator (parser.JSON, true);
     std::cout << JSON_gen.JSON_string << "\n";
 
-    // testing return_the_value_
-    cjparse::json_value value_to_return
+    // testing return_the_value 1 input
+    cjparse::json_value value_to_return = parser.return_the_value ("Image");
+    JSON_gen = cjparse_json_generator (value_to_return, true);
+    std::cout << "testing return the value in Image"
+              << "\n"
+              << JSON_gen.JSON_string << '\n';
+
+    // testing return_the_value multiple inputs
+    value_to_return
         = parser.return_the_value ({ "Image2", "Thumbnail", "Width" });
     JSON_gen = cjparse_json_generator (value_to_return, true);
     std::cout << "testing return the value in { \"Image2\", \"Thumbnail\", "
@@ -76,9 +83,23 @@ main ()
               << "\n"
               << JSON_gen.JSON_string << '\n';
 
-    // testing check_if_type
+    // testing check_if_type single name
     // checkiong if Width has a value of type "json_number"
-    bool checking_if_number = parser.check_if_type<cjparse::json_number> (
+    bool checking_if_number
+        = parser.check_if_type<cjparse::json_object> ("Image");
+    if (checking_if_number == true)
+        {
+            std::cout << "object named: " << "Image"
+                      << "  has value type T (tempate)" << '\n';
+        }
+    else
+        {
+            std::cout << "object named: " << "Image"
+                      << " has value type NOT T (template)" << '\n';
+        }
+    // testing check_if_type multiple names
+    // checkiong if Width has a value of type "json_number"
+    checking_if_number = parser.check_if_type<cjparse::json_number> (
         { "Image2", "Thumbnail", "Width" });
     if (checking_if_number == true)
         {


### PR DESCRIPTION
Now both "return_the_value" and "check_if_type" can be called with only 1 object "name" or "key" as well as with their respective tree traversing kind inputting "std::vector<string>"