### PR TITLE
Updated parsing algorithm so its compliant with RFC 8259

### DIFF
--- a/cjparse_use_examples.cpp
+++ b/cjparse_use_examples.cpp
@@ -57,8 +57,7 @@ std::string json_1 = R"([
 int
 main ()
 {
-    // Create the parser with the given JSON string (assuming cjparse class has
-    // a constructor that takes a string)
+    // construct the cjparse class inputing a JSON obliging string in.
     cjparse parser (json_2);
 
     // Print the JSON structure

--- a/src/cjparse_json_parser.cpp
+++ b/src/cjparse_json_parser.cpp
@@ -111,13 +111,13 @@ cjparse_json_parser::cjparse_parse_array (std::string &str,
             if (state == 0)
                 {
                     curr_outer_initial_delimeter = str.find_first_not_of (
-                        { str[curr_outer_final_delimeter], 0x20, 0x0c, 0x0a,
-                          0x0d, 0x09, 0x0b },
+                        { str[curr_outer_final_delimeter], 0x20, 0x0a, 0x0d,
+                          0x09 },
                         curr_outer_final_delimeter);
                     if (str[curr_outer_initial_delimeter] == ',')
                         curr_outer_initial_delimeter = str.find_first_not_of (
-                            { str[curr_outer_initial_delimeter], 0x20, 0x0c,
-                              0x0a, 0x0d, 0x09, 0x0b },
+                            { str[curr_outer_initial_delimeter], 0x20, 0x0a,
+                              0x0d, 0x09 },
                             curr_outer_initial_delimeter);
                     not_white_after_curr_outer_initial = str.find_first_of (
                         { ',', '}', ']' }, curr_outer_initial_delimeter + 1);
@@ -143,9 +143,9 @@ cjparse_json_parser::cjparse_parse_array (std::string &str,
                 {
                     curr_outer_final_delimeter
                         = not_white_after_curr_outer_initial;
-                    not_white_after_curr_outer_final = str.find_first_not_of (
-                        { 0x20, 0x0c, 0x0a, 0x0d, 0x09, 0x0b },
-                        curr_outer_final_delimeter);
+                    not_white_after_curr_outer_final
+                        = str.find_first_not_of ({ 0x20, 0x0a, 0x0d, 0x09 },
+                                                 curr_outer_final_delimeter);
                     state = 3;
                 }
             if (state == 3)
@@ -251,9 +251,9 @@ cjparse_json_parser::cjparse_parse_object (std::string &str,
                         {
                         } // HORRIBLE JSON
 
-                    curr_outer_initial_delimeter = str.find_first_not_of (
-                        { 0x20, 0x0c, 0x0a, 0x0d, 0x09, 0x0b },
-                        double_point_after_name + 1);
+                    curr_outer_initial_delimeter
+                        = str.find_first_not_of ({ 0x20, 0x0a, 0x0d, 0x09 },
+                                                 double_point_after_name + 1);
                     not_white_after_curr_outer_initial = str.find_first_of (
                         { ',', '}', ']' }, curr_outer_initial_delimeter);
                     str_temp = str.substr (curr_outer_initial_delimeter,
@@ -278,9 +278,9 @@ cjparse_json_parser::cjparse_parse_object (std::string &str,
                 {
                     curr_outer_final_delimeter
                         = not_white_after_curr_outer_initial;
-                    not_white_after_curr_outer_final = str.find_first_not_of (
-                        { 0x20, 0x0c, 0x0a, 0x0d, 0x09, 0x0b },
-                        curr_outer_final_delimeter);
+                    not_white_after_curr_outer_final
+                        = str.find_first_not_of ({ 0x20, 0x0a, 0x0d, 0x09 },
+                                                 curr_outer_final_delimeter);
                     state = 3;
                 }
             if (state == 3)
@@ -465,6 +465,5 @@ cjparse_json_parser::find_delimeters_check_if_comma_alter_state (
     final_delimeter = return_the_matching_pattern (str, initial_delimeter,
                                                    pattern, pattern_to_match);
     not_white_position_after_final_delimiter = str.find_first_not_of (
-        { pattern_to_match, 0x20, 0x0c, 0x0a, 0x0d, 0x09, 0x0b },
-        final_delimeter);
+        { pattern_to_match, 0x20, 0x0a, 0x0d, 0x09 }, final_delimeter);
 }

--- a/src/cjparse_json_parser.h
+++ b/src/cjparse_json_parser.h
@@ -30,13 +30,16 @@ class cjparse_json_parser
     cjparse::json_null cjparse_parse_value_null (std::string &str);
 
   private:
+    // internal helper functions
     int check_what_is_the_value (std::string &str);
 
+    // might be possible to improve this algo but it works like magic
     std::size_t
     return_the_matching_pattern (std::string &str,
                                  std::size_t pos_of_bracket_to_match,
                                  char pattern, char patter_to_match);
 
+    // exists only for redibility inside the while loops
     void find_delimeters_check_if_comma_alter_state (
         std::string &str, std::size_t &initial_delimeter,
         std::size_t &final_delimeter,


### PR DESCRIPTION
Also moved "main_cjparse.cpp" outside of src and now its called "cjparse_use_examples.cpp"