### PR TITLE
Now you can input a vector of strings of patterns to keep raw in json_string

### DIFF
--- a/cjparse_use_examples.cpp
+++ b/cjparse_use_examples.cpp
@@ -4,7 +4,7 @@
 #include <string>
 
 std::string json_3
-    = R"({"model":"deepseek-r1:14b","created_at":"2025-02-05T20:05:12.569859Z","response":"\u003cthink\u003e","done":false}
+    = R"({"model":"deepseek-r1:14b","created_at":"2025-02-05T20:05:12.569859Z","response":"\u003cthink\u003e \n the \n cool \n this will be raw \( \n pp ","done":false}
 )";
 std::string json_2 = R"({
         "Image": {
@@ -62,7 +62,7 @@ int
 main ()
 {
     std::cout << "we are here" << '\n';
-    cjparse parser (json_3);
+    cjparse parser (json_3, std::vector<std::string> ({ R"(\()", R"()\)" }));
     std::cout << "we are here 2" << '\n';
     cjparse::json_value val = parser.return_the_value ("response");
     std::cout << "we are here 3" << '\n';

--- a/include/cjparse.h
+++ b/include/cjparse.h
@@ -27,6 +27,13 @@ class cjparse
     cjparse (std::string &str);
     cjparse (std::stringstream &file);
 
+    // both of the following overloads can ignore the patterns inputed into the
+    // second argument when parsing the JSON string ex.
+    //   you want to parse unicodes like \u3920 but ignore '\\(' or '\\)'
+    cjparse (std::string &str, std::string json_string_pattern_to_keep_raw);
+    cjparse (std::string &str,
+             std::vector<std::string> json_string_pattern_to_keep_raw);
+
   protected:
     friend class cjparse_json_parser;
     friend class cjparse_json_generator;

--- a/include/cjparse_json_parser.h
+++ b/include/cjparse_json_parser.h
@@ -9,6 +9,15 @@ class cjparse_json_parser
     cjparse_json_parser (std::string &json_to_parse,
                          cjparse::cjparse_json_value &JSON_container);
 
+    cjparse_json_parser (std::string &json_to_parse,
+                         cjparse::cjparse_json_value &JSON_container,
+                         std::string json_string_pattern_to_keep_raw);
+
+    cjparse_json_parser (
+        std::string &json_to_parse,
+        cjparse::cjparse_json_value &JSON_container,
+        std::vector<std::string> json_string_pattern_to_keep_raw);
+
   public:
     // modify by reference the container due to nesting
     void cjparse_parse_value (std::string &str,
@@ -46,6 +55,9 @@ class cjparse_json_parser
         std::size_t &not_white_position_after_final_delimeter, char pattern);
 
     std::string decode_unicode (const std::string &str);
+
+  private:
+    std::vector<std::string> inside_str_ignore;
 };
 
 #endif // CJPARSE_JSON_PARSER

--- a/src/cjparse.cpp
+++ b/src/cjparse.cpp
@@ -3,6 +3,17 @@
 
 cjparse::cjparse (std::string &str) { cjparse_json_parser (str, JSON); }
 
+cjparse::cjparse (std::string &str,
+                  std::string json_string_pattern_to_keep_raw)
+{
+    cjparse_json_parser (str, JSON, json_string_pattern_to_keep_raw);
+}
+
+cjparse::cjparse (std::string &str,
+                  std::vector<std::string> json_string_patterns_to_keep_raw)
+{
+    cjparse_json_parser (str, JSON, json_string_patterns_to_keep_raw);
+}
 cjparse::cjparse (std::stringstream &fake_str)
 {
     // to be determied


### PR DESCRIPTION
Added to the library the ability to ignore certain back slashed patterns so they don't get parsed into their json_string unicode version and they stay raw