### PR TITLE
added valid JSON syntax checking before parsing to avoid errors

### DIFF
--- a/include/cjparse.h
+++ b/include/cjparse.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <optional>
 #include <sstream>
+#include <stack>
 #include <string>
 #include <unordered_map>
 #include <variant>

--- a/include/cjparse_json_parser.h
+++ b/include/cjparse_json_parser.h
@@ -41,7 +41,10 @@ class cjparse_json_parser
        std::string &json_to_parse, cjparse::cjparse_json_value &JSON_container,
        std::vector<std::string> json_string_pattern_to_keep_raw);
 
- public:
+ private:
+   bool cjparse_invalid_json_input (std::string &json_to_validate);
+
+ private:
    // modify by reference the container due to nesting
    void cjparse_parse_value (std::string &str,
                              cjparse::cjparse_json_value &value);


### PR DESCRIPTION
since its a basic and easy matching algo then might as well add the feature, will have to implement an exception handling with line and char where the syntax in the JSON input is failing.